### PR TITLE
Basestore optimisation and orphan filters

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -51,7 +51,6 @@ export default class App extends React.Component {
          * Set the state with the new data of the store
          */
         _handleAuthStoreChange() {
-            console.log('_handleAuthStoreChange');
             this.setState({
                 team: AuthStore.team
             });

--- a/src/components/alertButtons/ButtonList.jsx
+++ b/src/components/alertButtons/ButtonList.jsx
@@ -42,12 +42,18 @@ export default class ButtonList extends React.Component {
         // fill stores
         AlertButtonStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                AlertButtonStore.unloadData(this.AlertButtonStoreToken);
+
                 // save the component token
                 this.AlertButtonStoreToken = data.token;
             })
             .catch(error => console.log("load alert buttons error", error));
         TeamStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                TeamStore.unloadData(this.TeamStoreToken);
+
                 // save the component token
                 this.TeamStoreToken = data.token;
             })

--- a/src/components/barrelTypes/TypesList.jsx
+++ b/src/components/barrelTypes/TypesList.jsx
@@ -37,6 +37,9 @@ export default class TypesList extends React.Component {
         // fill the store
         BarrelTypeStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                BarrelTypeStore.unloadData(this.BarrelTypeStoreToken);
+
                 // save the component token
                 this.BarrelTypeStoreToken = data.token;
             })

--- a/src/components/barrels/BarBarrels.jsx
+++ b/src/components/barrels/BarBarrels.jsx
@@ -33,6 +33,9 @@ export default class BarBarrels extends React.Component {
         // fill the stores
         BarrelStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                BarrelStore.unloadData(this.BarrelStoreToken);
+
                 // save the component token
                 this.BarrelStoreToken = data.token;
                 // get distinct barrel types id and create objects with their id
@@ -42,6 +45,9 @@ export default class BarBarrels extends React.Component {
                 }
                 BarrelTypeStore.loadData(types)
                     .then(data => {
+                        // ensure that last token doen't exist anymore.
+                        BarrelTypeStore.unloadData(this.BarrelTypeStoreToken);
+
                         // save the component token
                         this.BarrelTypeStoreToken = data.token;
                     })

--- a/src/components/barrels/BarrelsList.jsx
+++ b/src/components/barrels/BarrelsList.jsx
@@ -38,6 +38,9 @@ export default class BarrelsList extends React.Component {
         // fill the store
         BarrelStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                BarrelStore.unloadData(this.BarrelStoreToken);
+
                 // save the component token
                 this.BarrelStoreToken = data.token;
             })

--- a/src/components/barrels/EditBarrel.jsx
+++ b/src/components/barrels/EditBarrel.jsx
@@ -36,6 +36,9 @@ export default class EditBarrel extends React.Component {
         // fill the store
         TeamStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                TeamStore.unloadData(this.TeamStoreToken);
+
                 // save the component token
                 this.TeamStoreToken = data.token;
             })
@@ -48,7 +51,7 @@ export default class EditBarrel extends React.Component {
 
     componentWillUnmount() {
         // clear store
-        TeamStore.unloadData(this._setTeams);
+        TeamStore.unloadData(this.TeamStoreToken);
         // remove the stores listeners
         TeamStore.removeChangeListener(this._setTeams);
     }

--- a/src/components/chat/MessageList.jsx
+++ b/src/components/chat/MessageList.jsx
@@ -24,6 +24,8 @@ export default class MessageList extends React.Component {
         // file the store
         ChatStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                ChatStore.unloadData(this.ChatStoreToken);
                 // save the component token
                 this.ChatStoreToken = data.token;
             })

--- a/src/components/partials/LoginAs.jsx
+++ b/src/components/partials/LoginAs.jsx
@@ -34,6 +34,9 @@ export default class LoginAs extends React.Component {
         // fill the stores
         UserStore.loadData(null)
             .then(data => {
+                // ensure that last token doen't exist anymore.
+                UserStore.unloadData(this.UserStoreToken);
+
                 // save the component token
                 this.UserStoreToken = data.token;
                 // get distinct teams id and create objects with their id
@@ -41,14 +44,18 @@ export default class LoginAs extends React.Component {
                 for (let i in teams) {
                     teams[i] = {id: teams[i]};
                 }
-                TeamStore.loadData(teams)
-                    .then(data => {
-                        // save the component token
-                        this.TeamStoreToken = data.token;
-                    })
-                    .catch(error => console.log("load teams error", error));
+
+
+                return TeamStore.loadData(teams)
             })
-            .catch(error => console.log("load users error", error));
+            .then(data => {
+                // ensure that last token doen't exist anymore.
+                TeamStore.unloadData(this.TeamStoreToken);
+
+                // save the component token
+                this.TeamStoreToken = data.token;
+            })
+            .catch(error => console.log("load users/team error", error));
         // listen the store change
         UserStore.addChangeListener(this._setUsers);
         TeamStore.addChangeListener(this._setUsers);

--- a/src/components/teams/TeamDetails.jsx
+++ b/src/components/teams/TeamDetails.jsx
@@ -70,24 +70,33 @@ export default class TeamDetails extends React.Component {
      * @param {strnig} id
      */
     _loadData(id) {
+        // Load only if a team is specified
+        if(!id) {
+            return;
+        }
+
         let newState = {};
         // Load team in store
         TeamStore.loadData({id: id})
         .then(data => {
+            // ensure that last token doen't exist anymore.
+            TeamStore.unloadData(this.TeamStoreToken);
+
             // save the component token
             this.TeamStoreToken = data.token;
-            newState.team = data.result[0];
 
             // Load members in store
-            return UserStore.loadData({team: id})
+            return UserStore.loadData({team: id});
         })
         .then(data => {
+            // ensure that last token doen't exist anymore.
+            UserStore.unloadData(this.UserStoreToken);
+
             // save the component token
             this.UserStoreToken = data.token;
-            newState.members = data.result;
 
-            // Finally set state with new data
-            this.setState(newState);
+            // Finally update component state
+            this._updateData();
         })
         .catch(error => {
             NotificationActions.error('Une erreur s\'est produite pendant le chargement des informations sur l\'équipe', error);

--- a/src/components/teams/TeamList.jsx
+++ b/src/components/teams/TeamList.jsx
@@ -63,6 +63,9 @@ export default class TeamList extends React.Component {
         // Load team in store
         TeamStore.loadData(null)
         .then(data => {
+            // ensure that last token doen't exist anymore.
+            TeamStore.unloadData(this.TeamStoreToken);
+
             // save the component token
             this.TeamStoreToken = data.token;
 

--- a/src/stores/AlertButtonStore.js
+++ b/src/stores/AlertButtonStore.js
@@ -8,29 +8,10 @@ class AlertButtonStore extends BaseStore {
         super('alertbutton', AlertButtonService.getAlertButtons);
 
         this.subscribe(() => this._handleActions.bind(this));
-
-        // binding
-        this._handleModelEvents = this._handleModelEvents.bind(this);
     }
 
     get buttons() {
         return this.getUnIndexedData();
-    }
-
-    /**
-     * Handle webSocket events about the AlertButton model
-     *
-     * @param {object} e : the event
-     */
-    _handleModelEvents(e) {
-        switch (e.verb) {
-            case "destroyed":
-                this._delete(e.id);
-                break;
-            case "created":
-                this._set(e.id, e.data);
-                break;
-        }
     }
 
     _handleActions(action) {

--- a/src/stores/BarrelStore.js
+++ b/src/stores/BarrelStore.js
@@ -7,31 +7,10 @@ class BarrelStore extends BaseStore {
         super('barrel', BarrelService.getBarrels);
 
         this.subscribe(() => this._handleActions.bind(this));
-
-        this._handleModelEvents = this._handleModelEvents.bind(this);
     }
 
     get barrels() {
         return this.getUnIndexedData();
-    }
-
-    /**
-     * Handle webSocket events about the Barrel model
-     *
-     * @param {object} e : the event
-     */
-    _handleModelEvents(e) {
-        switch (e.verb) {
-            case "destroyed":
-                this._delete(e.id);
-                break;
-            case "updated":
-                this._set(e.id, e.data);
-                break;
-            case "created":
-                this._set(e.id, e.data);
-                break;
-        }
     }
 
     /**

--- a/src/stores/BarrelTypeStore.js
+++ b/src/stores/BarrelTypeStore.js
@@ -7,28 +7,10 @@ class BarrelTypeStore extends BaseStore {
         super('barreltype', BarrelTypeService.getBarrelTypes);
 
         this.subscribe(() => this._handleActions.bind(this));
-
-        this._handleModelEvents = this._handleModelEvents.bind(this);
     }
 
     get types() {
         return this.getUnIndexedData();
-    }
-
-    /**
-     * Handle webSocket events about the BarrelType model
-     *
-     * @param {object} e : the event
-     */
-    _handleModelEvents(e) {
-        switch (e.verb) {
-            case "destroyed":
-                this._delete(e.id);
-                break;
-            case "created":
-                this._set(e.id, e.data);
-                break;
-        }
     }
 
     /**

--- a/src/stores/BaseStore.js
+++ b/src/stores/BaseStore.js
@@ -82,13 +82,17 @@ export default class BaseStore extends EventEmitter {
 
     /**
      * Remove the data used only for the component which has this token
+     * This function can be called safely with a null token
      *
      * @param {number|null} token: the component's token
      */
     unloadData(token) {
-        delete this._filters[token];
-        // reload only the data needed
-        this.fetchData();
+        if(this._filters[token]) {
+            // Delete filter
+            delete this._filters[token];
+            // reload only the data needed
+            this.fetchData();
+        }
     }
 
     /**

--- a/src/stores/BaseStore.js
+++ b/src/stores/BaseStore.js
@@ -128,7 +128,7 @@ export default class BaseStore extends EventEmitter {
      * @param {number|null} token: the component's token
      */
     unloadData(token) {
-        if(this._filters[token]) {
+        if(this._filters[token] !== undefined) {
             // Delete filter
             delete this._filters[token];
             // reload only the data needed

--- a/src/stores/BaseStore.js
+++ b/src/stores/BaseStore.js
@@ -55,6 +55,11 @@ export default class BaseStore extends EventEmitter {
             // No need to ask the server if there is no filter
             if(Array.isArray(filters) && filters.length === 0) {
                 this._setModelData([]);
+
+                resolve({
+                    result: [],
+                    token: componentToken
+                });
             }
             else {
                 // Check if the new filter already exist
@@ -63,7 +68,6 @@ export default class BaseStore extends EventEmitter {
                     for (let index in this._filters) {
                         if (index !== 'length' && index != componentToken &&
                         (this._filters[index] === null || Object.is(this._filters[index], this._filters[componentToken]))) {
-                            console.log(this._filters, index, componentToken, '0', 0);
                             fetch = false;
                             break;
                         }
@@ -73,7 +77,6 @@ export default class BaseStore extends EventEmitter {
                     // If there a filter has been deleted, then only refresh if there is no "null" filter
                     for (let index in this._filters) {
                         if (index !== 'length' && this._filters[index] === null) {
-                            console.log(this._filters, index);
                             fetch = false;
                             break;
                         }
@@ -82,7 +85,6 @@ export default class BaseStore extends EventEmitter {
 
                 // Fetch from the server only if it use usefull
                 if(fetch) {
-                    console.log('fetch', this._modelName, this.getFiltersSet());
                     this._fetchMethod(this.getFiltersSet())
                         .then(result => {
                             this._setModelData(result);
@@ -114,9 +116,16 @@ export default class BaseStore extends EventEmitter {
      * @returns {Promise}
      */
     loadData(filters) {
+        // Convert filter to array if it's a simple condition
+        if(filters !== null && !Array.isArray(filters)) {
+            filters = [filters];
+        }
+
+        // Add to the filter list
         const componentToken = this._filters.length;
         this._filters.length++;
         this._filters[componentToken] = filters;
+
         // refresh the store with the new filters
         return this.fetchData(componentToken);
     }

--- a/src/stores/BaseStore.js
+++ b/src/stores/BaseStore.js
@@ -58,20 +58,31 @@ export default class BaseStore extends EventEmitter {
             }
             else {
                 // Check if the new filter already exist
-                let exist = false;
-                if(componentToken) {
+                let fetch = true;
+                if(componentToken !== null) {
                     for (let index in this._filters) {
-                        if (index !== 'length' &&
-                        index !== componentToken &&
-                        Object.is(this._filters[index], this._filters[componentToken])) {
-                            exist = true;
+                        if (index !== 'length' && index != componentToken &&
+                        (this._filters[index] === null || Object.is(this._filters[index], this._filters[componentToken]))) {
+                            console.log(this._filters, index, componentToken, '0', 0);
+                            fetch = false;
+                            break;
+                        }
+                    }
+                }
+                else {
+                    // If there a filter has been deleted, then only refresh if there is no "null" filter
+                    for (let index in this._filters) {
+                        if (index !== 'length' && this._filters[index] === null) {
+                            console.log(this._filters, index);
+                            fetch = false;
                             break;
                         }
                     }
                 }
 
-                // Fetch from the server only if the new filter doens't already exist
-                if(exist) {
+                // Fetch from the server only if it use usefull
+                if(fetch) {
+                    console.log('fetch', this._modelName, this.getFiltersSet());
                     this._fetchMethod(this.getFiltersSet())
                         .then(result => {
                             this._setModelData(result);

--- a/src/stores/BaseStore.js
+++ b/src/stores/BaseStore.js
@@ -50,19 +50,27 @@ export default class BaseStore extends EventEmitter {
     fetchData(componentToken) {
 
         return new Promise((resolve, reject) => {
-            this._fetchMethod(this.getFiltersSet())
-                .then(result => {
-                    this._setModelData(result);
+            let filters = this.getFiltersSet();
 
-                    // listen model changes
-                    iosocket.on(this._modelName, this._handleModelEvents);
+            // No need to ask the server if there is no filter
+            if(Array.isArray(filters) && filters.length == 0) {
+                this._setModelData([]);
+            }
+            else {
+                this._fetchMethod(this.getFiltersSet())
+                    .then(result => {
+                        this._setModelData(result);
 
-                    resolve({
-                        result: this.find(this._filters[componentToken]),
-                        token: componentToken
-                    });
-                })
-                .catch(error => reject(error));
+                        // listen model changes
+                        iosocket.on(this._modelName, this._handleModelEvents);
+
+                        resolve({
+                            result: this.find(this._filters[componentToken]),
+                            token: componentToken
+                        });
+                    })
+                    .catch(error => reject(error));
+            }
         });
     }
 

--- a/src/stores/BaseStore.js
+++ b/src/stores/BaseStore.js
@@ -19,6 +19,7 @@ export default class BaseStore extends EventEmitter {
         // binding
         this._delete = this._delete.bind(this);
         this._set = this._set.bind(this);
+        this._handleModelEvents = this._handleModelEvents.bind(this);
     }
 
     subscribe(actionSubscribe) {
@@ -268,5 +269,24 @@ export default class BaseStore extends EventEmitter {
         }
 
         return out;
+    }
+
+    /**
+     * Handle webSocket events about the model
+     *
+     * @param {object} e : the event
+     */
+    _handleModelEvents(e) {
+        switch (e.verb) {
+            case "created":
+                this._set(e.id, e.data);
+                break;
+            case "updated":
+                this._set(e.id, e.data);
+                break;
+            case "destroyed":
+                this._delete(e.id);
+                break;
+        }
     }
 }

--- a/src/stores/ChatStore.js
+++ b/src/stores/ChatStore.js
@@ -7,24 +7,10 @@ class ChatStore extends BaseStore {
         super('message', ChatService.getMessages);
 
         this.subscribe(() => this._handleActions.bind(this));
-        this._handleModelEvents = this._handleModelEvents.bind(this);
     }
 
     get messages() {
         return this.getUnIndexedData();
-    }
-
-    /**
-     * Handle webSocket events about the Message model
-     *
-     * @param {object} e: the event
-     */
-    _handleModelEvents(e) {
-        switch (e.verb) {
-            case "created":
-                this._set(e.id, e.data);
-                break;
-        }
     }
 
     _handleActions(action) {

--- a/src/stores/TeamStore.js
+++ b/src/stores/TeamStore.js
@@ -7,28 +7,10 @@ class TeamStore extends BaseStore {
         super('team', TeamService.getTeams);
 
         this.subscribe(() => this._handleActions.bind(this));
-
-        this._handleModelEvents = this._handleModelEvents.bind(this);
     }
 
     get teams() {
         return this.getUnIndexedData();
-    }
-
-    /**
-     * Handle webSocket events about the Team model
-     *
-     * @param {object} e : the event
-     */
-    _handleModelEvents(e) {
-        switch (e.verb) {
-            case "destroyed":
-                this._delete(e.id);
-                break;
-            case "created":
-                this._set(e.id, e.data);
-                break;
-        }
     }
 
     /**

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -7,28 +7,10 @@ class UserStore extends BaseStore {
         super('user', UserService.getUsers);
 
         this.subscribe(() => this._handleActions.bind(this));
-
-        this._handleUserEvents = this._handleUserEvents.bind(this);
     }
 
     get users() {
         return this.getUnIndexedData();
-    }
-
-    /**
-     * Handle webSocket events about the User model
-     *
-     * @param {object} e : the event
-     */
-    _handleUserEvents(e) {
-        switch (e.verb) {
-            case "destroyed":
-                this._delete(e.id);
-                break;
-            case "updated":
-                this._set(e.id, e.data);
-                break;
-        }
     }
 
     /**


### PR DESCRIPTION
* Basestore will now try to ask the server only when it's necessary
* Some filters were added to stores without beiing removed because `loadData` was called twice at the same time. This should be fixed.
* Handle server events from BaseStore directly